### PR TITLE
Update babel config

### DIFF
--- a/config/dev.js
+++ b/config/dev.js
@@ -13,7 +13,8 @@ export default {
     babel({
       babelrc: false,
       exclude: 'node_modules/**',
-      presets: [ 'es2015-rollup', 'stage-0', 'react' ]
+      presets: [ [ 'es2015', { modules: false } ], 'stage-0', 'react' ],
+      plugins: [ 'external-helpers' ]
     }),
     cjs({
       exclude: 'node_modules/process-es6/**',

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "react-dom": "15.3.2"
   },
   "devDependencies": {
-    "babel-preset-es2015-rollup": "1.2.0",
+    "babel-plugin-external-helpers": "6.8.0",
+    "babel-preset-es2015": "6.16.0",
     "babel-preset-react": "6.11.1",
     "babel-preset-stage-0": "6.5.0",
     "browser-sync": "2.16.0",


### PR DESCRIPTION
Based on conversations in #2, https://github.com/rollup/rollup-plugin-babel/issues/72#issuecomment-238179853, and https://github.com/rollup/babel-preset-es2015-rollup/issues/11#issuecomment-238709022, this PR replaces `babel-preset-es2015-rollup` with `babel-preset-es2015` and adds `babel-plugin-external-helpers` to the babel config.
