### PR TITLE
switch npm command to npm start in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ npm install --global babel-react-rollup-starter
 Running the following command will open your default browser to `html/index-dev.html`. Thanks to [Browsersync](https://www.browsersync.io/), any modifications inside `src` trigger a browser refresh:
 
 ```sh
-npm test
+npm start
 ```
 
 To generate a development bundle:


### PR DESCRIPTION
@yamafaktory one more tiny PR! I noticed that `browser-sync` wasn't starting up with `npm test` as it said in the readme. This PR fixes the readme to say `npm start`, which does indeed start `browser-sync` and file watching 😄 
