### PR TITLE
index-dev.html now points to correct app.js location

### DIFF
--- a/html/index-dev.html
+++ b/html/index-dev.html
@@ -8,6 +8,6 @@
     </head>
     <body>
         <main></main>
-        <script src="build/app.js"></script>
+        <script src="../build/app.js"></script>
     </body>
 </html>


### PR DESCRIPTION
Previously it pointed to non-existent `html/build/` dir, while `build/` is on the same level as `html/`.